### PR TITLE
Resolve compile issues Arduino 1.6.6+

### DIFF
--- a/Hunt_The_Wumpus.ino
+++ b/Hunt_The_Wumpus.ino
@@ -38,8 +38,9 @@
 //       https://github.com/adafruit/Adafruit-MCP23017-Arduino-Library
 // --------------------------------------------------------------------------------
 #include <Wire.h>
-#include <Adafruit_MCP23017.h>
+#include <Wire.h>
 #include <Adafruit_RGBLCDShield.h>
+#include <utility/Adafruit_MCP23017.h>
 #include "Hunt_The_Wumpus.h"
 
 


### PR DESCRIPTION
This appears to have been a problem since 1.6.6.  Updating the library
for the correct compile order per the Adafruit RGB LCD
Library/HelloWorld sample.
